### PR TITLE
Hotfix/ci package regex

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -46,7 +46,6 @@ module.exports = (env, { mode, project = '', allProjects = false }) => {
   packages.forEach((item) => {
     const regexDirs = targetDirs.join('|');
     const packagePath = item.packagePath.match(`((${regexDirs})\/(.+))?\/package\.json$`);
-    console.log(packagePath);
     terminal.defaultColor(` * %s `, item.packageName).dim(`[%s]\n`, packagePath[0]);
   });
   terminal('\n');


### PR DESCRIPTION
An issue where would not capture the path of a `package.json` file due to the lack of root directory structure in CI/CD instances and the setup used there. This PR makes the path optional in the `package.json` regex.