### PR TITLE
docs: add pr template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+  - ampersarnie
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Which environments are you experiencing the issue on?
+      multiple: true
+      options:
+        - CI (CircleCI, Travis, etc)
+        - CLI (macOS, Windows, etc)
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: Shell

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: File a feature request
+title: "[Feature]: "
+labels: ["feature"]
+assignees:
+  - ampersarnie
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a feature, please provide as much information as possible.
+  - type: textarea
+    id: description
+    attributes:
+      label: The feature
+      description: Provide as much information as possible - detailed descriptions, code examples, etc.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!---
+Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
+Titles should use Jira ticket references where applicable.
+
+Example: [JIRA-0001] Outline additional requested information for Pull Requests.
+--->
+
+## Description
+<!---
+Please ensure `Fixes #{issue_number}/{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. 
+
+Example format:
+Fixes #18, [JIRA-0001](https://bigbite.atlassian.net/browse/JIRA-0001) and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aide with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
+--->
+
+## Change Log
+<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
+*
+*
+*


### PR DESCRIPTION
Adds a PR template to ensure that we're adding in correct information if we're getting additional contributors (I hope we do!). I've also added issue templates in preparation for if we make this public. Both of these can be adjusted at any time if we feel we're not getting the correct information from people.