### PR TITLE
Remove package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "license": "UNLICENSED",
-  "scripts": {
-    "build": "webpack --mode=development"
-  },
   "bin": {
     "build-tools": "./src/cli.js"
   },


### PR DESCRIPTION
## Description
We currently do not require any scripts for npm, etc so removing them to keep things clean and tidy until they are required.

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Removes `scripts` from `package.json`
