### PR TITLE
Disable viewBox removal in SVGO

### DIFF
--- a/src/commands/build/rules/images.js
+++ b/src/commands/build/rules/images.js
@@ -18,6 +18,17 @@ module.exports = ({ paths }) => [
   {
     test: /\.svg$/,
     issuer: /\.js?$/,
-    use: ['babel-loader', '@svgr/webpack', 'url-loader'],
+    use: [
+      'babel-loader',
+      'url-loader',
+      {
+        loader: '@svgr/webpack',
+        options: {
+          svgoConfig: {
+            removeViewBox: false,
+          },
+        },
+      },
+    ],
   },
 ];

--- a/src/commands/build/rules/images.js
+++ b/src/commands/build/rules/images.js
@@ -20,15 +20,18 @@ module.exports = ({ paths }) => [
     issuer: /\.js?$/,
     use: [
       'babel-loader',
-      'url-loader',
       {
         loader: '@svgr/webpack',
         options: {
           svgoConfig: {
-            removeViewBox: false,
+            plugins: [{
+              name: 'removeViewBox',
+              active: false,
+            }],
           },
         },
       },
+      'url-loader',
     ],
   },
 ];


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references where applicable.

Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description
<!---
Please ensure `Fixes #{issue_number}/{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. 

Example format:
Fixes #18, [JIRA-0001](https://bigbite.atlassian.net/browse/JIRA-0001) and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aide with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->
Fixes #32 - SVG's can have `viewBox` stripped out of them which will cause the appearance of cropping when the SVGs are displayed. This was caused by SVGO which is used by SVGR for optimisation. By default SVGO will strip out any instances of `viewBox` causing the cropping effect. To prevent this from happening we can disable the feature in the SVGR config.

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Adds SVGR config to disable `viewBox` removal in SVGO.