### PR TITLE
Correct logic around whether isAllProjects is true

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -61,7 +61,7 @@ exports.handler = async ({
   const projectsList = projects.split(',').filter((item) => item.length > 0);
   const targetDirs = ['client-mu-plugins', 'plugins', 'themes'];
   const hasTargetDirs = dirsExist(targetDirs);
-  const isAllProjects = (site && hasTargetDirs);
+  const isAllProjects = (site || hasTargetDirs);
 
   let paths = [];
 


### PR DESCRIPTION
Since `1.0.0-rc.2` the logic to determine if the build-tools should look for all projects was changed to be based on:

1. Is the `--site` flag present in the CLI command?
`AND`
2. Do either `client-mu-plugins`, `plugins`, or `themes` exist as subdirectories from the current location?

This breaks the ability for the build-tools to auto-detect when to run in 'site' mode, since you're now required to include the `--site` flag if you want this behaviour.

I don't think this was intentional and the above check should logically be `OR` so that the build-tools will run in site mode automatically when required, or if forced when the flag is used.