### PR TITLE
fix: add error check to bail in production mode

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -166,6 +166,12 @@ exports.handler = async ({
       process.stdout.write(err);
     }
 
+    if (stats.hasErrors() && mode === 'production') {
+      process.stdout.write(stats.toString() + '\n');
+      spinner.fail('Build cancelled.');
+      process.exit(1);
+    }
+
     /**
      * Avoids output which is a symptom in a longstanding
      * webpack issue where the watcher can loop due to FS_ACCURENCY

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -167,7 +167,7 @@ exports.handler = async ({
     }
 
     if (stats.hasErrors() && mode === 'production') {
-      process.stdout.write(stats.toString() + '\n');
+      process.stdout.write(stats.toString() + '\n\n\n');
       spinner.fail('Build cancelled.');
       process.exit(1);
     }

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -167,7 +167,7 @@ exports.handler = async ({
     }
 
     if (stats.hasErrors() && mode === 'production') {
-      process.stdout.write(stats.toString() + '\n\n\n');
+      process.stdout.write(stats.toString() + '\n\n\n\n');
       spinner.fail('Build cancelled.');
       process.exit(1);
     }


### PR DESCRIPTION
This is a small but important change, designed to force CI to exit if webpack encounters any errors generating a production build.

## Description
Currently, if webpack encounters any errors it will still compile and the build process will complete with the exit code `0`.

This means CI jobs will continue to run and deploy even though we would expect them not to.

To prevent this from occuring, this PR adds a condition to check for errors in the webpack build, and exits `1` if the script is running in production mode.

## Testing

This can be tested locally by forcing any kind of eslint error, e.g: `console.log({'test');` and running the build tools with and without the `--production` flag.

**Without flag (existing behaviour):**
![Screenshot 2022-12-22 at 14 00 42](https://user-images.githubusercontent.com/41474928/209150631-45fae11e-36c9-467b-99e8-b34873f63e01.png)

**With flag:**
![image](https://user-images.githubusercontent.com/41474928/209152006-0fcb0bd6-c6e5-4d1f-aec3-9b6985005eb4.png)

I've also tested on CI using one of our internal repos which is set up to use these build tools.

**Before (v1.1.0):**
<img width="1538" alt="image" src="https://user-images.githubusercontent.com/41474928/209155565-52c6830e-68ab-4385-83fa-3c2b3d4aaa62.png">

**After (this branch):**
<img width="1530" alt="image" src="https://user-images.githubusercontent.com/41474928/209156933-4f8d9788-8b73-4ae8-a17b-5d37599d8097.png">

On CI, it looks as though we require a change to our config to avoid running additional steps if the build tools fails to compile.