### PR TITLE
Add checks for which externals are set when running Dependency Extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigbite/build-tools",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "engines": {

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const { terminal } = require('terminal-kit');
@@ -103,10 +104,10 @@ exports.handler = async ({
 
   const configMap = packages.map((packageObject) => {
     const projectPath = path.resolve(packageObject.path);
-    const customConfig = require(projectPath + '/webpack.config.js');
+    const customWebpackConfigFile = projectPath + '/webpack.config.js';
+    const customConfig = fs.existsSync(customWebpackConfigFile) ? require(customWebpackConfigFile) : {};
 
-    let customWebpackConfig = {}
-    let defaultWebpackConfig = {
+    let customWebpackConfig = {
       extends: true,
       externals: {
         moment: 'moment',
@@ -114,15 +115,9 @@ exports.handler = async ({
         react: 'React',
         'react-dom': 'ReactDOM',
         jquery: 'jQuery',
-      }
+      },
+      ...customConfig,
     };
-
-    try {
-      customWebpackConfig = {
-        ...defaultWebpackConfig,
-        ...customConfig,
-      };
-    } catch (e) {}
 
     /**
      * Project config holds all information about a particular project,

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const { terminal } = require('terminal-kit');
@@ -103,22 +102,6 @@ exports.handler = async ({
   spinner.start('Building webpack configs.\n');
 
   const configMap = packages.map((packageObject) => {
-    const projectPath = path.resolve(packageObject.path);
-    const customWebpackConfigFile = projectPath + '/webpack.config.js';
-    const customConfig = fs.existsSync(customWebpackConfigFile) ? require(customWebpackConfigFile) : {};
-
-    let customWebpackConfig = {
-      extends: true,
-      externals: {
-        moment: 'moment',
-        lodash: ['lodash', 'lodash-es'],
-        react: 'React',
-        'react-dom': 'ReactDOM',
-        jquery: 'jQuery',
-      },
-      ...customConfig,
-    };
-
     /**
      * Project config holds all information about a particular project,
      * rather than directly pulling out paths from files or attempting
@@ -128,7 +111,7 @@ exports.handler = async ({
       name: packageObject.name,
       version: packageObject.json.version,
       paths: {
-        project: projectPath,
+        project: path.resolve(packageObject.path),
         config: path.resolve(`${__dirname}/configs`),
         src: path.resolve(`${packageObject.path}/src`),
         dist: path.resolve(`${packageObject.path}/dist`),
@@ -142,23 +125,9 @@ exports.handler = async ({
       clean: true,
       copy: true,
       mode,
-      customConfig: customWebpackConfig,
     };
 
-    let config = webpackConfig(PROJECT_CONFIG, mode);
-
-    if (!customWebpackConfig?.extends) {
-      config = customWebpackConfig;
-    } else if (customWebpackConfig) {
-      config = {
-        ...config,
-        ...customWebpackConfig,
-      };
-    }
-
-    delete config.extends;
-
-    return config;
+    return webpackConfig(PROJECT_CONFIG, mode);
   });
 
   let previousHash = '';

--- a/src/commands/build/plugins/custom/dependency-extraction/index.js
+++ b/src/commands/build/plugins/custom/dependency-extraction/index.js
@@ -17,7 +17,7 @@ class DependencyExtraction extends WordPressDependencyExtraction {
     super(options);
 
     this.name = options?.name ?? 'project';
-    this.customConfig = options?.customConfig ?? {};
+    this.externals = options?.externals ?? {};
 
     global.DependencyExtraction = {
       ...global.DependencyExtraction,
@@ -26,7 +26,7 @@ class DependencyExtraction extends WordPressDependencyExtraction {
   }
 
   externalizeWpDeps(_context, request, callback) {
-    const externalKeys = Object.keys(this.customConfig?.externals);
+    const externalKeys = Object.keys(this?.externals);
 
     const hardDefaults = [
       '@wordpress/',

--- a/src/commands/build/plugins/custom/dependency-extraction/index.js
+++ b/src/commands/build/plugins/custom/dependency-extraction/index.js
@@ -17,11 +17,30 @@ class DependencyExtraction extends WordPressDependencyExtraction {
     super(options);
 
     this.name = options?.name ?? 'project';
+    this.customConfig = options?.customConfig ?? {};
 
     global.DependencyExtraction = {
       ...global.DependencyExtraction,
       [this.name]: {},
     };
+  }
+
+  externalizeWpDeps(_context, request, callback) {
+    const externalKeys = Object.keys(this.customConfig?.externals);
+
+    const hardDefaults = [
+      '@wordpress/',
+      '@babel/runtime/regenerator',
+    ];
+
+    if (
+      !externalKeys.includes(request) &&
+      !hardDefaults.some(item => request.startsWith(item))
+    ) {
+      return callback();
+    }
+  
+    return super.externalizeWpDeps(_context, request, callback);
   }
 
   addAssets(compilation) {

--- a/src/commands/build/plugins/dependency-extraction.js
+++ b/src/commands/build/plugins/dependency-extraction.js
@@ -1,7 +1,8 @@
 const DependencyExtraction = require('./custom/dependency-extraction');
 
-module.exports = ({ name }) => {
+module.exports = ({ name, customConfig }) => {
   return new DependencyExtraction({
     name,
+    customConfig,
   });
 };

--- a/src/commands/build/plugins/dependency-extraction.js
+++ b/src/commands/build/plugins/dependency-extraction.js
@@ -1,8 +1,8 @@
 const DependencyExtraction = require('./custom/dependency-extraction');
 
-module.exports = ({ name, customConfig }) => {
+module.exports = ({ name }, externals) => {
   return new DependencyExtraction({
     name,
-    customConfig,
+    externals,
   });
 };

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -34,6 +34,8 @@ module.exports = (__PROJECT_CONFIG__, mode) => ({
   },
 
   externals: {
+    moment: 'moment',
+    lodash: ['lodash', 'lodash-es'],
     react: 'React',
     'react-dom': 'ReactDOM',
     jquery: 'jQuery',

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 
@@ -18,42 +19,69 @@ BROWSERSLIST_CONFIG = path.resolve(`${__dirname}/config`);
  * @param {string} projectName The name of the project - this will be the director target.
  * @returns {object} The full webpack configuration for the current project.
  */
-module.exports = (__PROJECT_CONFIG__, mode) => ({
-  mode,
-  entry: entrypoints(__PROJECT_CONFIG__.paths.src),
+module.exports = (__PROJECT_CONFIG__, mode) => {
+  const customWebpackConfigFile = __PROJECT_CONFIG__.paths.project + '/webpack.config.js';
+  const customConfig = fs.existsSync(customWebpackConfigFile) ? require(customWebpackConfigFile) : null;
 
-  resolve: {
-    modules: [__PROJECT_CONFIG__.paths.node_modules, 'node_modules'],
-    alias: webpackAlias(__PROJECT_CONFIG__.paths.src),
-  },
+  let webpackConfig = {
+    mode,
+    entry: entrypoints(__PROJECT_CONFIG__.paths.src),
 
-  output: {
-    // @TODO: This should be overridable at some point to allow for custom naming convention.
-    filename: () => (mode === 'production' ? '[name]-[contenthash:8].js' : '[name].js'),
-    path: path.resolve(`${__PROJECT_CONFIG__.paths.dist}/scripts`),
-  },
+    resolve: {
+      modules: [__PROJECT_CONFIG__.paths.node_modules, 'node_modules'],
+      alias: webpackAlias(__PROJECT_CONFIG__.paths.src),
+    },
 
-  externals: {
-    moment: 'moment',
-    lodash: ['lodash', 'lodash-es'],
-    react: 'React',
-    'react-dom': 'ReactDOM',
-    jquery: 'jQuery',
-  },
+    output: {
+      // @TODO: This should be overridable at some point to allow for custom naming convention.
+      filename: () => (mode === 'production' ? '[name]-[contenthash:8].js' : '[name].js'),
+      path: path.resolve(`${__PROJECT_CONFIG__.paths.dist}/scripts`),
+    },
 
-  watchOptions: {
-    ignored: ['node_modules'],
-  },
+    watchOptions: {
+      ignored: ['node_modules'],
+    },
 
-  performance: {
-    assetFilter: (assetFilename) => /\.(js|css)$/.test(assetFilename),
-    maxEntrypointSize: 20000000, // Large entry point size as we only need asset size. (2mb)
-    maxAssetSize: 500000, // Set max size to 500kb.
-  },
+    performance: {
+      assetFilter: (assetFilename) => /\.(js|css)$/.test(assetFilename),
+      maxEntrypointSize: 20000000, // Large entry point size as we only need asset size. (2mb)
+      maxAssetSize: 500000, // Set max size to 500kb.
+    },
 
-  devtool: mode === 'production' ? 'source-map' : 'inline-cheap-module-source-map',
+    devtool: mode === 'production' ? 'source-map' : 'inline-cheap-module-source-map',
 
-  plugins: [
+    externals: {
+      moment: 'moment',
+      lodash: ['lodash', 'lodash-es'],
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      jquery: 'jQuery',
+    },
+
+    module: {
+      rules: [
+        ...Rules.javascript(__PROJECT_CONFIG__),
+        ...Rules.images(__PROJECT_CONFIG__),
+        ...Rules.styles(__PROJECT_CONFIG__),
+      ],
+    },
+  };
+
+  if (customConfig) {
+    const shouldExtend = customConfig?.extends ?? true;
+    if (!shouldExtend) {
+      webpackConfig = customConfig;
+    } else if (webpackConfig) {
+      webpackConfig = {
+        ...webpackConfig,
+        ...customConfig,
+      };
+    }
+
+    delete webpackConfig.extends;
+  }
+
+  const plugins = [
     // Global vars for checking dev environment.
     new webpack.DefinePlugin({
       __DEV__: JSON.stringify(mode === 'development'),
@@ -61,7 +89,7 @@ module.exports = (__PROJECT_CONFIG__, mode) => ({
       __TEST__: JSON.stringify(process.env.NODE_ENV === 'test'),
     }),
 
-    Plugins.DependencyExtraction(__PROJECT_CONFIG__),
+    Plugins.DependencyExtraction(__PROJECT_CONFIG__, webpackConfig.externals),
     Plugins.ESLint(__PROJECT_CONFIG__),
     Plugins.MiniCssExtract(__PROJECT_CONFIG__),
     Plugins.StyleLint(__PROJECT_CONFIG__),
@@ -69,13 +97,9 @@ module.exports = (__PROJECT_CONFIG__, mode) => ({
     Plugins.Copy(__PROJECT_CONFIG__),
     Plugins.TemplateGenerator(__PROJECT_CONFIG__),
     Plugins.AssetMessage(__PROJECT_CONFIG__),
-  ],
+  ];
 
-  module: {
-    rules: [
-      ...Rules.javascript(__PROJECT_CONFIG__),
-      ...Rules.images(__PROJECT_CONFIG__),
-      ...Rules.styles(__PROJECT_CONFIG__),
-    ],
-  },
-});
+  webpackConfig.plugins = plugins;
+
+  return webpackConfig;
+};

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -71,7 +71,7 @@ module.exports = (__PROJECT_CONFIG__, mode) => {
     const shouldExtend = customConfig?.extends ?? true;
     if (!shouldExtend) {
       webpackConfig = customConfig;
-    } else if (webpackConfig) {
+    } else {
       webpackConfig = {
         ...webpackConfig,
         ...customConfig,


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references where applicable.

Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description
<!---
Please ensure `Fixes #{issue_number}/{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. 

Example format:
Fixes #18, [JIRA-0001](https://bigbite.atlassian.net/browse/JIRA-0001) and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aide with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->
In the previous PR to fix issues with dependency extraction (#83), the function that handled this was also preventing externals from being written where required. Because of this removal there has been a regression that caused externals to be overwritten as part of the dependency extraction. To get around this, and allow for dependencies - external, non-external and otherwise - we need to check which externals are being written or overwritten as [part of a custom webpack config](https://github.com/bigbite/build-tools/wiki/Custom-Webpack-Config).

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Add externals checking to DependencyExtraction plugin.
* Change how webpack config externals are created to main object.
