### PR TITLE
Alter eslint config to not use function

### DIFF
--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -1,61 +1,59 @@
 const babelConfig = require('./babel.js');
 const { eslintResolver } = require('./../src/utils/get-alias');
 
-module.exports = (projectConfig) => {
-  return {
-    globals: {
-      __DEV__: true,
-      __PROD__: true,
-      __TEST__: true,
-      wp: true,
+module.exports = {
+  globals: {
+    __DEV__: true,
+    __PROD__: true,
+    __TEST__: true,
+    wp: true,
+  },
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: ['airbnb', 'prettier'],
+  parser: '@babel/eslint-parser',
+  parserOptions: {
+    requireConfigFile: false,
+    babelOptions: {
+      ...babelConfig,
     },
-    env: {
-      browser: true,
-      es2021: true,
-      node: true,
-    },
-    extends: ['airbnb', 'prettier'],
-    parser: '@babel/eslint-parser',
-    parserOptions: {
-      requireConfigFile: false,
-      babelOptions: {
-        ...babelConfig,
+  },
+  plugins: ['@babel', 'react', 'prettier', 'jsdoc'],
+  settings: {
+    'import/resolver': eslintResolver(''),
+  },
+  rules: {
+    complexity: ['error', 10],
+    'prettier/prettier': 'error',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: true,
       },
-    },
-    plugins: ['@babel', 'react', 'prettier', 'jsdoc'],
-    settings: {
-      'import/resolver': eslintResolver(projectConfig.paths.src),
-    },
-    rules: {
-      complexity: ['error', 10],
-      'prettier/prettier': 'error',
-      'import/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: true,
+    ],
+    'react/jsx-uses-react': 'error',
+    'react/jsx-uses-vars': 'error',
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    'react/react-in-jsx-scope': 0,
+    'react/prop-types': 0,
+    'react/forbid-prop-types': 0,
+    'react/require-default-props': 0,
+    'arrow-parens': 2,
+    'jsdoc/require-jsdoc': [
+      'error',
+      {
+        require: {
+          ArrowFunctionExpression: true,
+          ClassDeclaration: true,
+          ClassExpression: true,
+          FunctionDeclaration: true,
+          FunctionExpression: true,
+          MethodDefinition: true,
         },
-      ],
-      'react/jsx-uses-react': 'error',
-      'react/jsx-uses-vars': 'error',
-      'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
-      'react/react-in-jsx-scope': 0,
-      'react/prop-types': 0,
-      'react/forbid-prop-types': 0,
-      'react/require-default-props': 0,
-      'arrow-parens': 2,
-      'jsdoc/require-jsdoc': [
-        'error',
-        {
-          require: {
-            ArrowFunctionExpression: true,
-            ClassDeclaration: true,
-            ClassExpression: true,
-            FunctionDeclaration: true,
-            FunctionExpression: true,
-            MethodDefinition: true,
-          },
-        },
-      ],
-    },
-  };
+      },
+    ],
+  },
 };

--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   plugins: ['@babel', 'react', 'prettier', 'jsdoc'],
   settings: {
-    'import/resolver': eslintResolver(''),
+    'import/resolver': eslintResolver('src'),
   },
   rules: {
     complexity: ['error', 10],

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -19,6 +19,26 @@ You will need to set the prettier config as prettier does not support the abilit
 }
 ```
 
+## VSCode (or other Editor)
+While most packages and config will work out of the box there are a number of configs that need defining to give yourself the best compatibility with your Editor setup. These include:
+
+- Prettier
+- ESLint
+
+To get these working correctly with your Editor you simply need to reference them in your `package.json` as seen below for `prettier` and `eslintConfig` keys.
+
+```json
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "prettier": "@bigbite/build-tools/configs/prettier",
+  "eslintConfig": {
+    "extends": "./node_modules/@bigbite/build-tools/configs/eslint",
+  },
+  "dependencies": {}
+}
+```
+
 ## Additional Setup.
 Copy/merge the applicable contents of the below files to their respective files in your project.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigbite/build-tools",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "engines": {

--- a/src/commands/build/plugins/eslint.js
+++ b/src/commands/build/plugins/eslint.js
@@ -4,7 +4,7 @@ const ESLintConfig = require('../../../../configs/eslint');
  * Sets the config for the ESLint webpack plugin.
  * @returns ESLintPlugin instance.
  */
-module.exports = (projectConfig) =>
+module.exports = () =>
   new ESLintPlugin({
-    baseConfig: ESLintConfig(projectConfig),
+    baseConfig: ESLintConfig,
   });


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references where applicable.

Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description
<!---
Please ensure `Fixes #{issue_number}/{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. 

Example format:
Fixes #18, [JIRA-0001](https://bigbite.atlassian.net/browse/JIRA-0001) and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aide with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->

An issue where ESLint config is not able to load in an editor such as VSCode due to the nature of using a function for compiling the config and linting config not being able to be set. Despite this, linting worked and the issue was not affecting build runs.

Additional config is required for having ESLint running within the editor experience and a `package.json` needs to be configured using `eslintConfig` properties:

```json
{
  "name": "my-package",
  "version": "1.0.0",
  "eslintConfig": {
    "extends": "./node_modules/@bigbite/build-tools/configs/eslint",
  },
  "dependencies": {}
}
```

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Change `eslint` config to not require function.
* Updated documentation with config.
