### PR TITLE
Create directories that do not exist from asset-settings.php path

### DIFF
--- a/src/commands/build/plugins/custom/template-generator/index.js
+++ b/src/commands/build/plugins/custom/template-generator/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { dirname } = require('path');
 
 /**
  * External dependencies
@@ -25,7 +26,13 @@ class TemplateGenerator {
       const templateString = templateContent(files);
 
       try {
-        fs.writeFileSync(filename, templateString);
+        fs.mkdir(dirname(filename), { recursive: true }, (err) => {
+          if (err) {
+            throw new Error(err);
+          }
+
+          fs.writeFileSync(filename, templateString);
+        });
       } catch (err) {
         console.log(err);
       }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references where applicable.

Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description
<!---
Please ensure `Fixes #{issue_number}/{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. 

Example format:
Fixes #18, [JIRA-0001](https://bigbite.atlassian.net/browse/JIRA-0001) and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aide with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->
Fixes #92 - As outlined in the issue, when running build, if the `inc` directory does not exist when the `asset-settings.php` file is being created, it will throw an error because `fs.writeFileSync` is unable to build the entire path as well as the file. To get around this we need to ensure the directory exists before creating the file.

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Adds directory check and creation before `asset-settings.php` is created.