### PR TITLE
Add jpg support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigbite/build-tools",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "engines": {

--- a/src/commands/build/rules/images.js
+++ b/src/commands/build/rules/images.js
@@ -5,7 +5,7 @@
  */
 module.exports = ({ paths }) => [
   {
-    test: /\.(png|woff|woff2|eot|ttf|gif)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+    test: /\.(png|woff|woff2|eot|ttf|gif|jpg|jpeg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
     loader: 'file-loader',
     issuer: /\.(css|scss|js|jsx|ts|tsx)?$/,
     options: {


### PR DESCRIPTION
## Description
This PR adds `jpg` and `jpeg` file extensions to the webpack file loader, so that we can import those image formats within for use within javascript.

## Change Log
* Adds `jpg` and `jpeg` file extensions to the webpack file loader

### Testing steps

- Create a project using the build tools
- Add a jpg image into the `src/static` directory
- Import into JS, e.g: `import myImage from "@Static/my-image.jpg"`
- Run the build tools watch/build process
- There should be no build errors

Previous error:
```
ERROR in ./src/static/images/nickname-generator/avatar-3.jpg 1:0
Module parse failed: Unexpected character '�' (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)
```