### PR TITLE
Change webpack config from native minification to use TerserPlugin.

### DIFF
--- a/example-site/plugins/test-plugin/src/components/DisplayComponent.tsx
+++ b/example-site/plugins/test-plugin/src/components/DisplayComponent.tsx
@@ -1,17 +1,22 @@
 import SVGAsComponent from '@Static/logo.svg';
 import SVGAsURL from '@Static/svg-file.svg?url';
 import MailIconPNG from '@Static/mail-icon.png';
+import { __ } from '@wordpress/i18n';
 
 import TestComponent from './TestComponent';
 
 /**
  * Display Component for an example block.
  */
-export default (): JSX.Element => (
+export default (): JSX.Element => {
+  // translators: This is some basic alt-text.
+  const svgAlt = __("Reference and SVG as the url", 'test-translation');
+
+  return (
   <>
     <div className="logo">
       <SVGAsComponent />
-      <img src={SVGAsURL} alt="Reference and SVG as the url" />
+      <img src={SVGAsURL} alt={svgAlt} />
     </div>
     <div>Example Block</div>
     <TestComponent additionalValue="This is not hidden" />
@@ -20,3 +25,4 @@ export default (): JSX.Element => (
     </div>
   </>
 );
+}

--- a/example-site/plugins/test-plugin/src/components/DisplayComponent.tsx
+++ b/example-site/plugins/test-plugin/src/components/DisplayComponent.tsx
@@ -1,28 +1,32 @@
 import SVGAsComponent from '@Static/logo.svg';
 import SVGAsURL from '@Static/svg-file.svg?url';
 import MailIconPNG from '@Static/mail-icon.png';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 import TestComponent from './TestComponent';
 
 /**
  * Display Component for an example block.
  */
-export default (): JSX.Element => {
+export default ({ attributes: { itemCount = 2 } }): JSX.Element => {
+  // General comment.
   // translators: This is some basic alt-text.
   const svgAlt = __("Reference and SVG as the url", 'test-translation');
 
+  // translators: %d is the number of items chosen.
+  const translatedValue = sprintf(_n("%d item", "%d items", itemCount, 'test-translation'), itemCount);
+
   return (
-  <>
-    <div className="logo">
-      <SVGAsComponent />
-      <img src={SVGAsURL} alt={svgAlt} />
-    </div>
-    <div>Example Block</div>
-    <TestComponent additionalValue="This is not hidden" />
-    <div>
-      <img src={MailIconPNG} alt="PNG Mail Icon for testing usage." />
-    </div>
-  </>
-);
+    <>
+      <div className="logo">
+        <SVGAsComponent />
+        <img src={SVGAsURL} alt={svgAlt} />
+      </div>
+      <div>Example Block</div>
+      <TestComponent additionalValue={translatedValue} />
+      <div>
+        <img src={MailIconPNG} alt="PNG Mail Icon for testing usage." />
+      </div>
+    </>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "stylelint-webpack-plugin": "^4.1.1",
         "svg-sprite-loader": "^6.0.9",
         "terminal-kit": "^2.1.8",
+        "terser-webpack-plugin": "^5.3.10",
         "ts-loader": "^9.4.2",
         "typescript": "^5.0.4",
         "url-loader": "^4.1.1",
@@ -15152,6 +15153,7 @@
       "version": "5.3.10",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
       "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigbite/build-tools",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "stylelint-webpack-plugin": "^4.1.1",
     "svg-sprite-loader": "^6.0.9",
     "terminal-kit": "^2.1.8",
+    "terser-webpack-plugin": "^5.3.10",
     "ts-loader": "^9.4.2",
     "typescript": "^5.0.4",
     "url-loader": "^4.1.1",

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const Plugins = require('./plugins');
 const Rules = require('./rules');
@@ -21,7 +22,9 @@ BROWSERSLIST_CONFIG = path.resolve(`${__dirname}/config`);
  */
 module.exports = (__PROJECT_CONFIG__, mode) => {
   const customWebpackConfigFile = __PROJECT_CONFIG__.paths.project + '/webpack.config.js';
-  const customConfig = fs.existsSync(customWebpackConfigFile) ? require(customWebpackConfigFile) : null;
+  const customConfig = fs.existsSync(customWebpackConfigFile)
+    ? require(customWebpackConfigFile)
+    : null;
 
   let webpackConfig = {
     mode,
@@ -47,6 +50,26 @@ module.exports = (__PROJECT_CONFIG__, mode) => {
       assetFilter: (assetFilename) => /\.(js|css)$/.test(assetFilename),
       maxEntrypointSize: 20000000, // Large entry point size as we only need asset size. (2mb)
       maxAssetSize: 500000, // Set max size to 500kb.
+    },
+
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          parallel: true,
+          terserOptions: {
+            output: {
+              comments: /translators:/i,
+            },
+            compress: {
+              passes: 2,
+            },
+            mangle: {
+              reserved: ['__', '_n', '_nx', '_x'],
+            },
+          },
+          extractComments: false,
+        }),
+      ],
     },
 
     devtool: mode === 'production' ? 'source-map' : 'inline-cheap-module-source-map',


### PR DESCRIPTION
## Description
The current build tools config relies on the native Webpack minification to handle its processes. However because of this we have little control over how it handles some aspects of our work. Translation comments and references are lost because of this lack of control, being stripped out which can cause issues with our translation process. To get around this, a move to the `TerserPlugin` using the [`@wordpress/scripts` configuration](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/config/webpack.config.js#L136) allows us to move forward and retain those comments.

This change also falls in line with current targets in moving the configuration to use that found from `@wordpress/scripts` so allows for an easier upgrade path.

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Add usage of the `TerserPlugin` for minification and optimisation.
