### PR TITLE
Update broken unit test to use correct FS mocking system

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -171,8 +171,7 @@ describe('CLI Build Command', () => {
   });
 
   it('runs specific projects and entrypoints mode when requested', () => {
-    mockFs({
-      ...requiredRealDirs,
+    mockVol.fromNestedJSON({
       plugins: {
         'my-plugin': {
           'package.json': JSON.stringify({


### PR DESCRIPTION
## Description
Unit tests are currently failing due to one of them referencing `mockFs` which is not installed in the project.

This PR fixes the unit test by using `mockVol` inline with the other tests.