### PR TITLE
Ensure block and non-block entrypoints can be built together

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -42,6 +42,9 @@ describe('CLI Build Command', () => {
       webpack.util = {
         createHash: jest.fn(),
       };
+      webpack.sources = {
+        RawSource: jest.fn(),
+      };
 
       return webpack;
     });
@@ -171,8 +174,7 @@ describe('CLI Build Command', () => {
   });
 
   it('runs specific projects and entrypoints mode when requested', () => {
-    mockFs({
-      ...requiredRealDirs,
+    mockVol.fromNestedJSON({
       plugins: {
         'my-plugin': {
           'package.json': JSON.stringify({

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -52,15 +52,25 @@ module.exports = (__PROJECT_CONFIG__, mode) => {
       ],
     },
     entry: () => {
+      let projectEntrypoints = {};
+      try {
+        projectEntrypoints = entrypoints(
+          __PROJECT_CONFIG__.paths.src,
+          __PROJECT_CONFIG__.filteredEntrypoints,
+        );
+      } catch (error) {
+        // don't do anything if entrypoints are not found
+      }
+
       if (!containsBlockFiles(__PROJECT_CONFIG__.paths.project)) {
-        return entrypoints(__PROJECT_CONFIG__.paths.src, __PROJECT_CONFIG__.filteredEntrypoints);
+        return projectEntrypoints;
       }
 
       process.env.WP_SRC_DIRECTORY = __PROJECT_CONFIG__.paths.dir + '/src';
 
       return {
         ...wpConfig.entry(),
-        ...entrypoints(__PROJECT_CONFIG__.paths.src, __PROJECT_CONFIG__.filteredEntrypoints),
+        ...projectEntrypoints,
       };
     },
   };

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { cloneDeep } = require('lodash');
-const wpScriptsConfig = require( '@wordpress/scripts/config/webpack.config' );
+const wpScriptsConfig = require('@wordpress/scripts/config/webpack.config');
 
 const Rules = require('./rules');
 const entrypoints = require('../../utils/entrypoints');
@@ -11,8 +11,6 @@ const { containsBlockFiles } = require('./../../utils/projectpaths');
 // Define the bundled BrowserList config location/directory.
 // eslint-disable-next-line no-undef
 BROWSERSLIST_CONFIG = path.resolve(`${__dirname}/config`);
-
-const SRC_DIRECTORY_DEFAULT = process.env?.WP_SRC_DIRECTORY ?? 'src';
 
 /**
  * Build the webpack configuration for the current project.
@@ -24,7 +22,9 @@ const SRC_DIRECTORY_DEFAULT = process.env?.WP_SRC_DIRECTORY ?? 'src';
  */
 module.exports = (__PROJECT_CONFIG__, mode) => {
   const customWebpackConfigFile = __PROJECT_CONFIG__.paths.project + '/webpack.config.js';
-  const customConfig = fs.existsSync(customWebpackConfigFile) ? require(customWebpackConfigFile) : null;
+  const customConfig = fs.existsSync(customWebpackConfigFile)
+    ? require(customWebpackConfigFile)
+    : null;
 
   const wpConfig = cloneDeep(wpScriptsConfig);
 
@@ -52,23 +52,18 @@ module.exports = (__PROJECT_CONFIG__, mode) => {
       ],
     },
     entry: () => {
-      process.env.WP_SRC_DIRECTORY = SRC_DIRECTORY_DEFAULT; // Default
-
       if (!containsBlockFiles(__PROJECT_CONFIG__.paths.project)) {
         return entrypoints(__PROJECT_CONFIG__.paths.src, __PROJECT_CONFIG__.filteredEntrypoints);
       }
 
-      if (containsBlockFiles(__PROJECT_CONFIG__.paths.project)) {
-        process.env.WP_SRC_DIRECTORY = __PROJECT_CONFIG__.paths.dir + '/src';
-      }
+      process.env.WP_SRC_DIRECTORY = __PROJECT_CONFIG__.paths.dir + '/src';
 
-      return wpConfig.entry();
-    }
+      return {
+        ...wpConfig.entry(),
+        ...entrypoints(__PROJECT_CONFIG__.paths.src, __PROJECT_CONFIG__.filteredEntrypoints),
+      };
+    },
   };
-
-  if (!containsBlockFiles(__PROJECT_CONFIG__.paths.project)) {
-    webpackConfig.entry = entrypoints(__PROJECT_CONFIG__.paths.src, __PROJECT_CONFIG__.filteredEntrypoints);
-  }
 
   if (customConfig) {
     const shouldExtend = customConfig?.extends ?? true;

--- a/src/utils/entrypoints.js
+++ b/src/utils/entrypoints.js
@@ -13,23 +13,22 @@ module.exports = (src, filteredEntrypoints) => {
   const pathToEntryPoints = path.resolve(process.cwd(), entrypoints);
 
   if (!fs.existsSync(pathToEntryPoints)) {
-    return fs.readdirSync(`${src}/blocks/`).filter(dir => fs.existsSync(`${src}/blocks/${dir}/index.js`)).map(dir => `${src}/blocks/${dir}/index.js`);
+    throw new Error(`Unable to find entrypoints folder in ${src}.`);
   }
 
-  return fs.readdirSync(pathToEntryPoints).reduce(
-    (accumulator, file) => {
-      const type = file.split('.')[0];
+  return fs.readdirSync(pathToEntryPoints).reduce((accumulator, file) => {
+    const type = file.split('.')[0];
 
-      // If types are provided, only watch/build those.
-      if (filteredEntrypoints.length > 0) {
-        if (!filteredEntrypoints.includes(type)) {
-          return accumulator;
-        }
+    // If types are provided, only watch/build those.
+    if (filteredEntrypoints.length > 0) {
+      if (!filteredEntrypoints.includes(type)) {
+        return accumulator;
       }
+    }
 
-      return {
-        ...accumulator,
-        [type]: path.resolve(pathToEntryPoints, file),
-      };
+    return {
+      ...accumulator,
+      [type]: path.resolve(pathToEntryPoints, file),
+    };
   }, {});
 };


### PR DESCRIPTION
## Description

This PR allows both block entrypoints (`src/blocks/[blockname]/*.js`) and regular entrypoints (`src/entrypoints/*.js`) to be built simultaneously.

This accommodates projects that contain both, or only one of either of the above entrypoint types.