### PR TITLE
Add script modules support

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -3,7 +3,7 @@ const { terminal } = require('terminal-kit');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const ora = require('ora');
 
-const webpackConfig = require('./build/webpack');
+const { scriptsConfig, modulesConfig } = require('./build/webpack');
 
 const spinner = ora();
 
@@ -63,7 +63,9 @@ exports.handler = async ({
 
   spinner.start('Building webpack configs.\n');
 
-  const configMap = packages.map((packageObject) => {
+  let configMap = [];
+
+  packages.forEach((packageObject) => {
     // Empty array means all entrypoints.
     let filteredEntrypoints = [];
 
@@ -77,7 +79,8 @@ exports.handler = async ({
 
     const projectConfig = getProjectConfig(packageObject, mode, filteredEntrypoints);
 
-    return webpackConfig(projectConfig, mode);
+    configMap.push(scriptsConfig(projectConfig, mode));
+    configMap.push(modulesConfig(projectConfig, mode));
   });
 
   let previousHash = '';

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -1,7 +1,12 @@
+process.env.WP_EXPERIMENTAL_MODULES = true;
+
 const fs = require('fs');
 const path = require('path');
 const { cloneDeep } = require('lodash');
-const wpScriptsConfig = require('@wordpress/scripts/config/webpack.config');
+const [
+  wpScriptsConfig,
+  wpScriptsModulesConfig,
+] = require('@wordpress/scripts/config/webpack.config');
 
 const Rules = require('./rules');
 const entrypoints = require('../../utils/entrypoints');
@@ -20,7 +25,7 @@ BROWSERSLIST_CONFIG = path.resolve(`${__dirname}/config`);
  * @param {string} projectName The name of the project - this will be the director target.
  * @returns {object} The full webpack configuration for the current project.
  */
-module.exports = (__PROJECT_CONFIG__, mode) => {
+const scriptsConfig = (__PROJECT_CONFIG__, mode) => {
   const customWebpackConfigFile = __PROJECT_CONFIG__.paths.project + '/webpack.config.js';
   const customConfig = fs.existsSync(customWebpackConfigFile)
     ? require(customWebpackConfigFile)
@@ -90,4 +95,29 @@ module.exports = (__PROJECT_CONFIG__, mode) => {
   }
 
   return webpackConfig;
+};
+
+const modulesConfig = (__PROJECT_CONFIG__, mode) => {
+  const wpConfig = cloneDeep(wpScriptsModulesConfig);
+
+  let webpackConfig = {
+    ...wpConfig,
+    mode,
+    resolve: {
+      ...wpConfig.resolve,
+      alias: webpackAlias(__PROJECT_CONFIG__.paths.src),
+    },
+
+    output: {
+      ...wpConfig.output,
+      path: path.resolve(`${__PROJECT_CONFIG__.paths.dist}`),
+    },
+  };
+
+  return webpackConfig;
+};
+
+module.exports = {
+  scriptsConfig,
+  modulesConfig,
 };


### PR DESCRIPTION
## Description

This PR is in initial implementation of [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) support using wp-scripts.

The way that wp-scripts is structured means it will export an array of webpack configs ([multicompiler](https://webpack.js.org/api/node/#multicompiler) mode) if script modules are to be built - one for regular scripts and another for the script modules.

By setting the `process.env.WP_EXPERIMENTAL_MODULES` environment variable to `true`, we can import both configs from wp-scripts, and pass both to our compiler during the project mapping process.

I haven't tested this thoroughly yet, but wanted to raise awareness of the functionality and get some more eyes on this for feedback/ideas - since script modules are a hard requirement in order to make use of the [Interactivity API](https://make.wordpress.org/core/2024/03/04/interactivity-api-dev-note/).

## Testing steps
- Install this plugin - [reading-mode.zip](https://github.com/user-attachments/files/18742072/reading-mode.zip)
- From plugin root:
  - `npm i`
  - `npm run build` - run wp-scripts build
  - `npm run build-tools` run build-tools build
- Inspect contents of generated `build` (wp-scripts and `dist` (build-tools) directories
- In `reading-mode.php`, uncomment one of the block registration lines
- Insert `reading mode` block into a post, check editor and frontend output (should render an interactive toggle)
- Switch to the other block registration
- Inspect the block again

Check compatibility with additional project entrypoints, both block and non-block.