### PR TITLE
Re-add eslint and stylelint plugins

### DIFF
--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { cloneDeep } = require('lodash');
 const wpScriptsConfig = require('@wordpress/scripts/config/webpack.config');
 
+const plugins = require('./plugins');
 const Rules = require('./rules');
 const entrypoints = require('../../utils/entrypoints');
 const { webpackAlias } = require('./../../utils/get-alias');
@@ -73,6 +74,12 @@ module.exports = (__PROJECT_CONFIG__, mode) => {
         ...projectEntrypoints,
       };
     },
+
+    plugins: [
+      ...wpConfig.plugins,
+      plugins.ESLint(__PROJECT_CONFIG__),
+      plugins.StyleLint(__PROJECT_CONFIG__),
+    ],
   };
 
   if (customConfig) {


### PR DESCRIPTION
## Description

These plugins had been removed from the `release/2.0.0` branch, but are required in order to lint JS/CSS during webpack compilation, since `wp-scripts` doesn't do this.

We rely on this during development as well as in CI, so we need to add these plugins back in.