### PR TITLE
Update block file existence check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-alpha.6",
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "engines": {

--- a/src/utils/projectpaths.js
+++ b/src/utils/projectpaths.js
@@ -49,21 +49,24 @@ const findAllProjectPaths = (directories, projectsList) => {
 
 /**
  * Checks whether there are blocks that exist in the given path.
- * 
- * Will check for the existance of {path}/src/blocks/{blockDir}/index.js
- * 
+ *
+ * Will check for the existence of {path}/src/blocks/{blockDir}/block.json
+ *
  * @param {string} path The path to check where blocks exist.
- * @returns 
+ *
+ * @return {boolean} Whether or not block files exist.
  */
 const containsBlockFiles = (path) => {
   let exists = false;
 
   if (fs.existsSync(`${path}/src/blocks/`)) {
-    exists = fs.readdirSync(`${path}/src/blocks/`).map(dir => fs.existsSync(`${path}/src/blocks/${dir}/index.js`)).every(Boolean);
+    exists = fs
+      .readdirSync(`${path}/src/blocks/`)
+      .find((dir) => fs.existsSync(`${path}/src/blocks/${dir}/block.json`));
   }
 
   return exists;
-}
+};
 
 /**
  * Confirms the given package.json is a valid build-tools project


### PR DESCRIPTION
## Description

This fixes an issue where you could not build a project that contains only `blocks` and no `entrypoints` by updating the logic around whether a project is deemed to have block files to build to look for the presence of `block.json` instead of `index.js`.

This is because a `block.json` file is the entrypoint for processing block assets via webpack, and you may or may not have a file named `index.js` present, depending on what you're doing with the block.

Also checks whether _any_ block.json files are present, rather than requiring _every_ directory in `/blocks` to contain one.