### PR TITLE
fix: adds context path assignment to webpack configs

### DIFF
--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -31,6 +31,8 @@ BROWSERSLIST_CONFIG = path.resolve(`${__dirname}/config`);
  * @returns {object} The full webpack configuration for the current project.
  */
 const scriptsConfig = (__PROJECT_CONFIG__, mode) => {
+  process.env.WP_SOURCE_PATH = __PROJECT_CONFIG__.paths.dir + '/src';
+  
   const customWebpackConfigFile = __PROJECT_CONFIG__.paths.project + '/webpack.config.js';
   const customConfig = fs.existsSync(customWebpackConfigFile)
     ? require(customWebpackConfigFile)

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -29,7 +29,7 @@ const scriptsConfig = (__PROJECT_CONFIG__, mode) => {
   // webpack config utilises the correct source path for each project.
   const configPath = '@wordpress/scripts/config/webpack.config';
   delete require.cache[require.resolve(configPath)];
-  process.env.WP_SOURCE_PATH = __PROJECT_CONFIG__.paths.dir + '/src';
+  process.env.WP_SOURCE_PATH = '.' + __PROJECT_CONFIG__.paths.dir + '/src';
 
   const [wpScriptsConfig] = require(configPath);
   const wpConfig = cloneDeep(wpScriptsConfig);
@@ -39,30 +39,6 @@ const scriptsConfig = (__PROJECT_CONFIG__, mode) => {
   const customConfig = fs.existsSync(customWebpackConfigFile)
     ? require(customWebpackConfigFile)
     : null;
-
-  // @TODO: There's a possibility this can be moved to a plugin.
-  // Using compiler or compilation hooks may resolve the need to
-  // inject here as this context is taken directly from the
-  // WP_SRC_DIRECTORY node environment variable in node.
-  // Usage can be found in the following places:
-  // - https://github.com/WordPress/gutenberg/blob/abe37675d4e25f35828e780c49588e01d26f4e31/packages/scripts/scripts/start.js#L33
-  // - https://github.com/WordPress/gutenberg/blob/abe37675d4e25f35828e780c49588e01d26f4e31/packages/scripts/utils/config.js#L184
-  // This environment variable will be need to be set for each build
-  // run.
-  // Alternatively, more flexible solution can be used where we're
-  // with less predefined array indices.
-  for (let i in wpConfig.plugins) {
-    let { constructor } = wpConfig.plugins[i];
-
-    switch (constructor.name) {
-      case 'CopyPlugin':
-        wpConfig.plugins[i].patterns = wpConfig.plugins[i].patterns.map((pattern) => ({
-          ...pattern,
-          context: __PROJECT_CONFIG__.paths.src,
-        }));
-        break;
-    }
-  }
 
   let webpackConfig = {
     ...wpConfig,

--- a/src/commands/build/webpack.js
+++ b/src/commands/build/webpack.js
@@ -66,8 +66,6 @@ const scriptsConfig = (__PROJECT_CONFIG__, mode) => {
         };
         break;
     }
-
-    console.log(wpConfig.plugins[i]);
   }
 
   let webpackConfig = {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references where applicable.

Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description
Due to how webpack handles the config, the current assignment of the project source directory to the `WP_SOURCE_PATH` environment variable is never accurate. Webpack constructs the config _before_ build processes are run, so in cases where we have multiple projects running `WP_SOURCE_PATH` will always be set to the _last_ project.

If we use the `example-site` setup as our illustration we have the following projects:

```
client-mu-plugins/test-client-plugin
plugins/block-and-entrypoint-plugin
plugins/block-plugin
plugins/standards
plugin/test-plugin
themes/test-theme
```

In this case, `WP_SOURCE_PATH` will ultimately be set to `themes/test-theme/src`, thus meaning every project will be targeting that for `block.json` copy, and PHP files.

To get around this, we need to ensure that `WP_SOURCE_PATH` is assignable every round of build per-project with the correct target, rather than ahead of build. Unfortunately I haven't been able to find the correct compiler or compilation hooks where this can be done. There may be other sensible methods of doing this also that might be worth exploring, but I've not had time to explore other ideas.

In the mean time I have this change which overwrites the `context` of plugins that require a `src` directory to ensure that they are set. This works on a per-project config level so each has their correct paths. It's not ideal but does provide a way around and forward.

<!---
Please ensure `Fixes #{issue_number}/{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. 

Example format:
Fixes #18, [JIRA-0001](https://bigbite.atlassian.net/browse/JIRA-0001) and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aide with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->

## Change Log
<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
* Set `WP_COPY_PHP_FILES_TO_DIST` to `true` - _Note: made an assumption on this and it may need removing._
* Set `WP_SOURCE_PATH` to a reasonable default of `/src` until correct assignment can be made.
* Add process for assigning source directory contexts to required plugins.
