### PR TITLE
Explicitly use prettier and eslint configs.

### DIFF
--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -1,4 +1,5 @@
 const babelConfig = require('./babel.js');
+const prettierConfig = require('./prettier.js');
 const { eslintResolver } = require('./../src/utils/get-alias');
 
 module.exports = {
@@ -35,7 +36,13 @@ module.exports = {
   plugins: ['@babel', 'react', 'prettier', 'jsdoc', 'import', '@typescript-eslint/eslint-plugin'],
   rules: {
     complexity: ['error', 10],
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+			'error',
+			prettierConfig,
+			{
+				usePrettierrc: false
+			}
+		],
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -3,7 +3,7 @@ const prettierConfig = require('./prettier.js');
 const { eslintResolver } = require('./../src/utils/get-alias');
 
 module.exports = {
-	root: true,
+  root: true,
   globals: {
     __DEV__: true,
     __PROD__: true,
@@ -38,12 +38,12 @@ module.exports = {
   rules: {
     complexity: ['error', 10],
     'prettier/prettier': [
-			'error',
-			prettierConfig,
-			{
-				usePrettierrc: false
-			}
-		],
+      'error',
+      prettierConfig,
+      {
+        usePrettierrc: false
+      }
+    ],
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -3,6 +3,7 @@ const prettierConfig = require('./prettier.js');
 const { eslintResolver } = require('./../src/utils/get-alias');
 
 module.exports = {
+	root: true,
   globals: {
     __DEV__: true,
     __PROD__: true,

--- a/configs/prettier.js
+++ b/configs/prettier.js
@@ -1,4 +1,5 @@
 const config = {
+	tabs: false,
   printWidth: 100,
   trailingComma: 'all',
   arrowParens: 'always',

--- a/configs/prettier.js
+++ b/configs/prettier.js
@@ -1,5 +1,5 @@
 const config = {
-	tabs: false,
+  tabs: false,
   printWidth: 100,
   trailingComma: 'all',
   arrowParens: 'always',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigbite/build-tools",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/build-tools",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Provides configuration for the Big Bite Build Tools.",
   "author": "Paul Taylor <paul@bigbite.net> (https://github.com/ampersarnie)",
   "engines": {


### PR DESCRIPTION
## Description
When working with setups and repos where there are configs lower in the directory tree, both ESLint and Prettier pick them up and use them instead of the bundled. This can cause a number of errors, for example:

- Different `React` requirements that our plugin/theme is expecting, so ESLint will throw errors.
- Different indentation configuration so while an existing plugin/theme may have 2 spaces used for JS, a root config will throw many errors if it is expecting tabs.

## Testing
- Use build-tools in a plugin (`./wp-content/plugins/my-plugin`)
- Add a prettier config lower in the project directory tree (`./wp-content/.prettierrc`), with a different config to our bundled - Using tabs over spaces for example.
- Add an eslint config lower in the project directory tree (`./wp-content/.eslintrc`)
- **Failing:** Run build from plugin - prettier and eslint configs will be used for the plugin.

## Change Log
* Explicitly use the bundled prettier config.
* Disable tabs in prettier to keep inline with our JS expectations.
* Prevent ESLint getting configs lower in the directory tree.
